### PR TITLE
fix(articles/2026-03-29-bash-safe-scripting.md): Add mise as alternative installation method for shellcheck

### DIFF
--- a/articles/2026-03-29-bash-safe-scripting.md
+++ b/articles/2026-03-29-bash-safe-scripting.md
@@ -127,7 +127,7 @@ start-main
 
 [shellcheck](https://github.com/koalaman/shellcheck) は bash/sh スクリプトの静的解析ツールです。上記のような罠を自動で検出してくれます。
 
-インストールは `apt install shellcheck` や `brew install shellcheck` で。
+インストールは `apt install shellcheck` や `brew install shellcheck` で。[mise](https://mise.jdx.dev/) を使っているなら `mise use shellcheck` でも OK です。
 
 実行は単純：
 


### PR DESCRIPTION
## Summary
Updated the bash safe scripting article to mention `mise` as an alternative installation method for shellcheck.

## Changes
- Added a note about using `mise use shellcheck` as an alternative to `apt install` and `brew install` for installing shellcheck
- This provides users who already use mise for tool management with a convenient installation option

## Details
The change adds a helpful reference for developers using [mise](https://mise.jdx.dev/) (a polyglot tool version manager) to install shellcheck alongside the existing package manager installation methods.

https://claude.ai/code/session_01VANBxwdmCfKvtYTKSBS2PX